### PR TITLE
prepare docs publishing for legacy java docs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "mongo-java-driver"]
+	path = mongo-java-driver
+	url = git@github.com:mongodb/mongo-java-driver
+	branch = gh-pages

--- a/README.md
+++ b/README.md
@@ -7,15 +7,12 @@ Documentation for the synchronous Java driver is available at
 https://docs.mongodb.com/drivers/java/sync and the source is available at
 https://github.com/mongodb/docs-java
 
- 1. landing - the front page of all the java docs
- 2. reference - the reference site for the current version of the driver
-
 ## Build Instructions
 
 After making required changes, run the `publish-docs` script with the version:
 
 ```sh
-./publish-docs version
+./publish-docs <version>
 ```
 
 This will initiate a submodule (if necessary) that tracks the *gh-pages* branch

--- a/README.md
+++ b/README.md
@@ -10,3 +10,14 @@ https://github.com/mongodb/docs-java
  1. landing - the front page of all the java docs
  2. reference - the reference site for the current version of the driver
 
+## Build Instructions
+
+After making required changes, run the `publish-docs` script with the version:
+
+```sh
+./publish-docs version
+```
+
+This will initiate a submodule (if necessary) that tracks the *gh-pages* branch
+of the [mongo-java-driver](https://github.com/mongodb/mongo-java-driver). It will
+then build the documents, copy items over as necessary, and push them.

--- a/publish-docs
+++ b/publish-docs
@@ -11,7 +11,7 @@ fi
 version=$1
 echo version: ${version}
 
-# reference docs
+# make the reference docs
 cd reference || exit
 rm -rf public
 hugo
@@ -23,7 +23,7 @@ rm -rf public
 
 cd ..
 
-# landing docs
+# make the landing page
 cd landing || exit
 rm -rf public
 hugo
@@ -33,7 +33,8 @@ rm -rf public
 
 cd ..
 
-# update remote
+# publish the docs
+# you will need push access to the mongo-java-driver repo's gh-pages branch
 cd mongo-java-driver
 git add .
 git ci -a -m fixup!

--- a/publish-docs
+++ b/publish-docs
@@ -38,4 +38,4 @@ cd mongo-java-driver
 git add .
 git ci -a -m fixup!
 git rebase -i --root
-git push origin -f
+git push origin gh-pages -f

--- a/publish-docs
+++ b/publish-docs
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+git submodule add -b gh-pages git@github.com:mongodb/mongo-java-driver 2>/dev/null
+git submodule update --remote || exit
+
+if [[ -z $1 || $# -gt 1 ]]; then
+    echo "Usage: publish-docs <version>"
+    exit 1
+fi
+
+version=$1
+echo version: ${version}
+
+# reference docs
+cd reference || exit
+rm -rf public
+hugo
+
+rm -rf ../mongo-java-driver/${version}
+mkdir ../mongo-java-driver/${version}
+cp -a public/* ../mongo-java-driver/${version}
+rm -rf public
+
+cd ..
+
+# landing docs
+cd landing || exit
+rm -rf public
+hugo
+
+rsync -a public/ ../mongo-java-driver/
+rm -rf public
+
+cd ..
+
+# update remote
+cd mongo-java-driver
+git add .
+git ci -a -m fixup!
+git rebase -i --root
+git push origin -f


### PR DESCRIPTION
This adds the necessary script to automate building the reactive and scala docs and publishing them to github pages.