### PR TITLE
DOCSP-25494 Remove import to removed Success enum

### DIFF
--- a/reference/content/driver-reactive/getting-started/quick-start.md
+++ b/reference/content/driver-reactive/getting-started/quick-start.md
@@ -49,7 +49,6 @@ import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoClients;
 import com.mongodb.reactivestreams.client.MongoCollection;
 import com.mongodb.reactivestreams.client.MongoDatabase;
-import com.mongodb.reactivestreams.client.Success;
 
 import org.bson.Document;
 


### PR DESCRIPTION
The Success enum was removed in [this commit](https://github.com/mongodb/mongo-java-driver/commit/24780d53705de06d511af7e5cae18081449c9401#diff-f131339886684aea58a734024a931831b001a22d2d776cb52d5c17ed2cdf811bL24) in driver version 4.0.0.