### PR TITLE
DOCPS-25669: updates for v4.7

### DIFF
--- a/landing/data/releases.toml
+++ b/landing/data/releases.toml
@@ -1,8 +1,8 @@
-current = "4.7.0-beta0"
+current = "4.7.0"
 
 [[versions]]
   status = "current"
-  version = "4.7.0-beta0"
+  version = "4.7.0"
   docs = "./4.7"
   api = "./4.7/apidocs"
 

--- a/reference/data/mongodb.toml
+++ b/reference/data/mongodb.toml
@@ -1,6 +1,6 @@
 # Update versions in config.toml as well
 githubRepo = "mongo-java-driver"
 githubBranch = "master"
-currentVersion = "4.7.0-beta0"
+currentVersion = "4.7.0"
 highlightTheme = "idea.css"
 apiUrl = "/apidocs/"

--- a/reference/layouts/shortcodes/install.html
+++ b/reference/layouts/shortcodes/install.html
@@ -31,7 +31,7 @@
 <section class="gradle hidden">
 <pre><code>
   dependencies {
-      compile '{{$groupId}}:{{$artifactId}}:{{$version}}{{- if $scalaVersion -}}_{{$scalaVersion}}{{- end -}}{{- if $classifier -}}:{{$classifier}}{{- end -}}'
+      implementation '{{$groupId}}:{{$artifactId}}:{{$version}}{{- if $scalaVersion -}}_{{$scalaVersion}}{{- end -}}{{- if $classifier -}}:{{$classifier}}{{- end -}}'
   }
   repositories {
     maven {
@@ -64,7 +64,7 @@
 <section class="gradle hidden">
 <pre><code>
   dependencies {
-      compile '{{$groupId}}:{{$artifactId}}:{{$version}}{{- if $scalaVersion -}}_{{$scalaVersion}}{{- end -}}{{- if $classifier -}}:{{$classifier}}{{- end -}}'
+      implementation '{{$groupId}}:{{$artifactId}}:{{$version}}{{- if $scalaVersion -}}_{{$scalaVersion}}{{- end -}}{{- if $classifier -}}:{{$classifier}}{{- end -}}'
   }
 
 </code></pre>


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/DOCSP-25669

This PR includes updates for v4.7 only.
Once v4.7 is published, another PR will be created for v4.8.0-beta0 docs.
Once v4.8.0-beta0 docs are published, the older static html files will be updated to include the fixes mentioned in the ticket.