### PR TITLE
Use https to enable personal access token auth

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "mongo-java-driver"]
 	path = mongo-java-driver
-	url = git@github.com:mongodb/mongo-java-driver
+	url = https://github.com/mongodb/mongo-java-driver.git
 	branch = gh-pages

--- a/publish-docs
+++ b/publish-docs
@@ -19,7 +19,7 @@ referenceDir="reference"
 landingDir="landing"
 
 echo "Adding mongo-java-driver submodule (if necessary)..."
-git submodule add -b gh-pages git@github.com:mongodb/mongo-java-driver 2> /dev/null && git submodule update --remote
+git submodule add -b gh-pages https://github.com/mongodb/mongo-java-driver.git 2> /dev/null && git submodule update --remote
 
 # make the reference docs
 echo "[START] Building reference docs version: ${version}"


### PR DESCRIPTION
The current M1 workflow requires using a Docker container and installing a GitHub Personal Access Token for auth. The PAT only works with https and not with ssh (fails silently).