### PR TITLE
DOCSP-25476: v4.8.0 GA update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,5 @@
 	path = mongo-java-driver
 	url = https://github.com/mongodb/mongo-java-driver.git
 	branch = gh-pages
+[submodule "gh-pages"]
+	branch = gh-pages

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ The aforementioned documentation resides in the "gh-pages" branch of
 the [MongoDB Java Driver](https://github.com/mongodb/mongo-java-driver).
 
 For the current Java Sync driver reference documentation, see the
-[https://www.mongodb.com/docs/drivers/java/sync](Java Sync reference docs site)
-or the source in the [https://github.com/mongodb/docs-java](docs-java repository).
+[Java Sync reference docs site](https://www.mongodb.com/docs/drivers/java/sync)
+or the source in the [docs-java repository](https://github.com/mongodb/docs-java).
 
 ## Build Requirements
 

--- a/landing/data/releases.toml
+++ b/landing/data/releases.toml
@@ -2,7 +2,7 @@ current = "4.8.0-beta0"
 
 [[versions]]
   status = "current"
-  version = "4.8.0-beta"
+  version = "4.8.0-beta0"
   docs = "./4.8"
   api = "./4.8/apidocs"
 
@@ -12,6 +12,7 @@ current = "4.8.0-beta0"
   docs = "./4.7"
   api = "./4.7/apidocs"
 
+[[versions]]
   status = "4.6.0"
   version = "4.6.0"
   docs = "./4.6"

--- a/landing/data/releases.toml
+++ b/landing/data/releases.toml
@@ -1,8 +1,8 @@
-current = "4.8.0-beta0"
+current = "4.8.0"
 
 [[versions]]
   status = "current"
-  version = "4.8.0-beta0"
+  version = "4.8.0"
   docs = "./4.8"
   api = "./4.8/apidocs"
 

--- a/landing/data/releases.toml
+++ b/landing/data/releases.toml
@@ -1,12 +1,17 @@
-current = "4.7.0"
+current = "4.8.0-beta0"
 
 [[versions]]
   status = "current"
-  version = "4.7.0"
+  version = "4.8.0-beta"
+  docs = "./4.8"
+  api = "./4.8/apidocs"
+
+[[versions]]
+  status = "4.7.2"
+  version = "4.7.2"
   docs = "./4.7"
   api = "./4.7/apidocs"
 
-[[versions]]
   status = "4.6.0"
   version = "4.6.0"
   docs = "./4.6"

--- a/publish-docs
+++ b/publish-docs
@@ -19,7 +19,7 @@ referenceDir="reference"
 landingDir="landing"
 
 echo "Adding mongo-java-driver submodule (if necessary)..."
-git submodule add -b gh-pages https://github.com/mongodb/mongo-java-driver.git 2> /dev/null && git submodule update --remote
+git submodule add -b gh-pages https://github.com/mongodb/mongo-java-driver.git 2> /dev/null && git submodule update --init --recursive --remote
 
 # make the reference docs
 echo "[START] Building reference docs version: ${version}"

--- a/reference/config.toml
+++ b/reference/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/mongo-java-driver/4.7"
+baseURL = "/mongo-java-driver/4.8"
 languageCode = "en-us"
 title = "MongoDB JVM Drivers"
 theme = "mongodb"

--- a/reference/content/driver-reactive/getting-started/installation.md
+++ b/reference/content/driver-reactive/getting-started/installation.md
@@ -18,4 +18,4 @@ The recommended way to get started using one of the drivers in your project is w
 
 The Reactive Streams implementation for asynchronous stream processing with non-blocking back pressure.
 
-{{< install artifactId="mongodb-driver-reactivestreams" version="4.7.0">}}
+{{< install artifactId="mongodb-driver-reactivestreams" version="4.8.0">}}

--- a/reference/content/driver-reactive/getting-started/installation.md
+++ b/reference/content/driver-reactive/getting-started/installation.md
@@ -18,4 +18,4 @@ The recommended way to get started using one of the drivers in your project is w
 
 The Reactive Streams implementation for asynchronous stream processing with non-blocking back pressure.
 
-{{< install artifactId="mongodb-driver-reactivestreams" version="4.8.0-beta0">}}
+{{< install artifactId="mongodb-driver-reactivestreams" version="4.8.0">}}

--- a/reference/content/driver-reactive/getting-started/installation.md
+++ b/reference/content/driver-reactive/getting-started/installation.md
@@ -18,4 +18,4 @@ The recommended way to get started using one of the drivers in your project is w
 
 The Reactive Streams implementation for asynchronous stream processing with non-blocking back pressure.
 
-{{< install artifactId="mongodb-driver-reactivestreams" version="4.8.0">}}
+{{< install artifactId="mongodb-driver-reactivestreams" version="4.8.0-beta0">}}

--- a/reference/content/driver-reactive/index.md
+++ b/reference/content/driver-reactive/index.md
@@ -26,6 +26,7 @@ For tutorials for some frequently used operations, see the [Tutorials section]({
 
 | Release | Documentation |
 |---------|---------------|
+| 4.7.x   | {{< releases version="4.7" >}} |
 | 4.6.x   | {{< releases version="4.6" >}} |
 | 4.5.x   | {{< releases version="4.5" >}} |
 | 4.4.x   | {{< releases version="4.4" >}} |

--- a/reference/content/driver-scala/getting-started/installation.md
+++ b/reference/content/driver-scala/getting-started/installation.md
@@ -20,8 +20,8 @@ The Reactive Streams based Scala implementation for asynchronous stream processi
 
 ### Scala 2.12
 
-{{< install artifactId="mongo-scala-driver" version="4.7.0" groupId="org.mongodb.scala" scalaVersion="2.12">}}
+{{< install artifactId="mongo-scala-driver" version="4.8.0-beta0" groupId="org.mongodb.scala" scalaVersion="2.12">}}
 
 ### Scala 2.11
 
-{{< install artifactId="mongo-scala-driver" version="4.7.0" groupId="org.mongodb.scala" scalaVersion="2.11">}}
+{{< install artifactId="mongo-scala-driver" version="4.8.0-beta0" groupId="org.mongodb.scala" scalaVersion="2.11">}}

--- a/reference/content/driver-scala/getting-started/installation.md
+++ b/reference/content/driver-scala/getting-started/installation.md
@@ -20,8 +20,8 @@ The Reactive Streams based Scala implementation for asynchronous stream processi
 
 ### Scala 2.12
 
-{{< install artifactId="mongo-scala-driver" version="4.8.0-beta0" groupId="org.mongodb.scala" scalaVersion="2.12">}}
+{{< install artifactId="mongo-scala-driver" version="4.8.0" groupId="org.mongodb.scala" scalaVersion="2.12">}}
 
 ### Scala 2.11
 
-{{< install artifactId="mongo-scala-driver" version="4.8.0-beta0" groupId="org.mongodb.scala" scalaVersion="2.11">}}
+{{< install artifactId="mongo-scala-driver" version="4.8.0" groupId="org.mongodb.scala" scalaVersion="2.11">}}

--- a/reference/content/whats-new.md
+++ b/reference/content/whats-new.md
@@ -7,7 +7,7 @@ title = "What's New"
   pre = "<i class='fa fa-level-up'></i>"
 +++
 
-For versions v4.5 and later, refer to the [What's New - Java Sync Documentation](https://www.mongodb.com/docs/drivers/java/sync/v4.6/whats-new/).
+For versions v4.5 and later, refer to the [What's New - Java Sync Documentation](https://www.mongodb.com/docs/drivers/java/sync/current/whats-new/).
 
 # What's new in 4.4
 

--- a/reference/content/whats-new.md
+++ b/reference/content/whats-new.md
@@ -7,13 +7,7 @@ title = "What's New"
   pre = "<i class='fa fa-level-up'></i>"
 +++
 
-# What's new in 4.6
-
-* Refer to [What's New - Java Sync Documentation](https://www.mongodb.com/docs/drivers/java/sync/v4.6/whats-new/) for more information.
-
-# What's new in 4.5
-
-* Refer to [What's New - Java Sync Documentation](https://www.mongodb.com/docs/drivers/java/sync/v4.5/whats-new/) for more information.
+For versions v4.5 and later, refer to the [What's New - Java Sync Documentation](https://www.mongodb.com/docs/drivers/java/sync/v4.6/whats-new/).
 
 # What's new in 4.4
 

--- a/reference/content/whats-new.md
+++ b/reference/content/whats-new.md
@@ -7,7 +7,7 @@ title = "What's New"
   pre = "<i class='fa fa-level-up'></i>"
 +++
 
-For versions v4.5 and later, refer to the [What's New - Java Sync Documentation](https://www.mongodb.com/docs/drivers/java/sync/current/whats-new/).
+For versions 4.5 and later, refer to the [What's New - Java Sync Documentation](https://www.mongodb.com/docs/drivers/java/sync/current/whats-new/).
 
 # What's new in 4.4
 

--- a/reference/data/mongodb.toml
+++ b/reference/data/mongodb.toml
@@ -1,6 +1,6 @@
 # Update versions in config.toml as well
 githubRepo = "mongo-java-driver"
 githubBranch = "master"
-currentVersion = "4.7.0"
+currentVersion = "4.8.0-beta0"
 highlightTheme = "idea.css"
 apiUrl = "/apidocs/"

--- a/reference/data/mongodb.toml
+++ b/reference/data/mongodb.toml
@@ -1,6 +1,6 @@
 # Update versions in config.toml as well
 githubRepo = "mongo-java-driver"
 githubBranch = "master"
-currentVersion = "4.8.0-beta0"
+currentVersion = "4.8.0"
 highlightTheme = "idea.css"
 apiUrl = "/apidocs/"

--- a/reference/themes/mongodb/layouts/partials/header/metaRedirect.html
+++ b/reference/themes/mongodb/layouts/partials/header/metaRedirect.html
@@ -1,7 +1,12 @@
+{{ if ( and ( findRE ".*mongo-java-driver/4.8/.+" .URL ) ( not ( findRE ".*/apidocs/.*" .URL )) ( not ( findRE ".*/driver-scala/.*" .URL )) (not ( findRE ".*/driver-reactive/.*" .URL )) ( not ( findRE ".*/whats-new/.*" .URL ))) }}
+  <link rel="canonical" href="https://www.mongodb.com/docs/drivers/java/sync/current/"/>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+  <meta http-equiv="refresh" content="0;url=https://www.mongodb.com/docs/drivers/java/sync/upcoming/" />
+{{ end }}
 {{ if ( and ( findRE ".*mongo-java-driver/4.7/.+" .URL ) ( not ( findRE ".*/apidocs/.*" .URL )) ( not ( findRE ".*/driver-scala/.*" .URL )) (not ( findRE ".*/driver-reactive/.*" .URL )) ( not ( findRE ".*/whats-new/.*" .URL ))) }}
   <link rel="canonical" href="https://www.mongodb.com/docs/drivers/java/sync/current/"/>
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <meta http-equiv="refresh" content="0;url=https://www.mongodb.com/docs/drivers/java/sync/current/" />
+  <meta http-equiv="refresh" content="0;url=https://www.mongodb.com/docs/drivers/java/sync/v4.7/" />
 {{ end }}
 {{ if ( and ( findRE ".*mongo-java-driver/4.6/.+" .URL ) ( not ( findRE ".*/apidocs/.*" .URL )) ( not ( findRE ".*/driver-scala/.*" .URL )) (not ( findRE ".*/driver-reactive/.*" .URL )) ( not ( findRE ".*/whats-new/.*" .URL ))) }}
   <link rel="canonical" href="https://www.mongodb.com/docs/drivers/java/sync/v4.6/"/>

--- a/reference/themes/mongodb/layouts/partials/header/metaRedirect.html
+++ b/reference/themes/mongodb/layouts/partials/header/metaRedirect.html
@@ -1,10 +1,10 @@
 {{ if ( and ( findRE ".*mongo-java-driver/4.8/.+" .URL ) ( not ( findRE ".*/apidocs/.*" .URL )) ( not ( findRE ".*/driver-scala/.*" .URL )) (not ( findRE ".*/driver-reactive/.*" .URL )) ( not ( findRE ".*/whats-new/.*" .URL ))) }}
   <link rel="canonical" href="https://www.mongodb.com/docs/drivers/java/sync/current/"/>
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <meta http-equiv="refresh" content="0;url=https://www.mongodb.com/docs/drivers/java/sync/upcoming/" />
+  <meta http-equiv="refresh" content="0;url=https://www.mongodb.com/docs/drivers/java/sync/current/" />
 {{ end }}
 {{ if ( and ( findRE ".*mongo-java-driver/4.7/.+" .URL ) ( not ( findRE ".*/apidocs/.*" .URL )) ( not ( findRE ".*/driver-scala/.*" .URL )) (not ( findRE ".*/driver-reactive/.*" .URL )) ( not ( findRE ".*/whats-new/.*" .URL ))) }}
-  <link rel="canonical" href="https://www.mongodb.com/docs/drivers/java/sync/current/"/>
+  <link rel="canonical" href="https://www.mongodb.com/docs/drivers/java/sync/v4.7/"/>
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
   <meta http-equiv="refresh" content="0;url=https://www.mongodb.com/docs/drivers/java/sync/v4.7/" />
 {{ end }}


### PR DESCRIPTION
JIRA:
https://jira.mongodb.org/browse/DOCSP-25476

Includes updates from https://github.com/mongodb/docs-java-other/pull/23 since it hasn't been merged.