### PR TITLE
DOCSP-25495: Add await call for Reactive Streams examples

### DIFF
--- a/reference/content/driver-reactive/getting-started/quick-start.md
+++ b/reference/content/driver-reactive/getting-started/quick-start.md
@@ -266,7 +266,7 @@ To insert these documents to the collection, pass the list of documents to the
 
 ```java
 var subscriber = new OperationSubscriber<InsertManyResult>();
-coll.insertMany(documents).subscribe(subscriber);
+collection.insertMany(documents).subscribe(subscriber);
 // Wait for the insertMany operation to complete
 subscriber.await();
 ```

--- a/reference/content/driver-reactive/getting-started/quick-start.md
+++ b/reference/content/driver-reactive/getting-started/quick-start.md
@@ -190,7 +190,10 @@ Once you have the `MongoCollection` object, you can insert documents into the co
 To insert a single document into the collection, you can use the collection's [`insertOne()`]({{< apiref "mongodb-driver-reactivestreams" "com/mongodb/reactivestreams/client/MongoCollection.html#insertOne(TDocument)" >}}) method.
 
 ```java
-collection.insertOne(doc).subscribe(new OperationSubscriber<InsertOneResult>());
+var subscriber = new OperationSubscriber<InsertOneResult>();
+collection.insertOne(doc).subscribe(subscriber);
+// Wait for the insertOne operation to complete
+subscriber.await();
 ```
 
 {{% note %}}
@@ -262,7 +265,10 @@ To insert these documents to the collection, pass the list of documents to the
 [`insertMany()`]({{< apiref "mongodb-driver-reactivestreams" "com/mongodb/reactivestreams/client/MongoCollection.html#insertMany(java.util.List)" >}}) method.
 
 ```java
-collection.insertMany(documents).subscribe(new ObservableSubscriber<InsertManyResult>());
+var subscriber = new OperationSubscriber<InsertManyResult>();
+coll.insertMany(documents).subscribe(subscriber);
+// Wait for the insertMany operation to complete
+subscriber.await();
 ```
 
 Here we block on the `Publisher` to finish so that when we call the next operation we know the data has been inserted into the database!


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/DOCSP-25495

No staging or build.

Note: this only changes documentation generated for future versions. The work to update v4.6+ versions will be done manually on the rendered HTML in the mongodb-java-driver gh-pages branch.