### PR TITLE
update install version for Scala and Java RS

### DIFF
--- a/reference/content/driver-reactive/getting-started/installation.md
+++ b/reference/content/driver-reactive/getting-started/installation.md
@@ -18,4 +18,4 @@ The recommended way to get started using one of the drivers in your project is w
 
 The Reactive Streams implementation for asynchronous stream processing with non-blocking back pressure.
 
-{{< install artifactId="mongodb-driver-reactivestreams" version="4.10.0">}}
+{{< install artifactId="mongodb-driver-reactivestreams" version="4.11.0">}}

--- a/reference/content/driver-scala/getting-started/installation.md
+++ b/reference/content/driver-scala/getting-started/installation.md
@@ -20,8 +20,8 @@ The Reactive Streams based Scala implementation for asynchronous stream processi
 
 ### Scala 2.12
 
-{{< install artifactId="mongo-scala-driver" version="4.10.0" groupId="org.mongodb.scala" scalaVersion="2.12">}}
+{{< install artifactId="mongo-scala-driver" version="4.11.0" groupId="org.mongodb.scala" scalaVersion="2.12">}}
 
 ### Scala 2.11
 
-{{< install artifactId="mongo-scala-driver" version="4.10.0" groupId="org.mongodb.scala" scalaVersion="2.11">}}
+{{< install artifactId="mongo-scala-driver" version="4.11.0" groupId="org.mongodb.scala" scalaVersion="2.11">}}


### PR DESCRIPTION
The changes to these templates should update the version field in the installation guides:

- https://mongodb.github.io/mongo-java-driver/4.11/driver-reactive/getting-started/installation/
- https://mongodb.github.io/mongo-java-driver/4.11/driver-scala/getting-started/installation/