### PR TITLE
add redirect for java rs v5

### DIFF
--- a/reference/themes/mongodb/layouts/partials/header/metaRedirect.html
+++ b/reference/themes/mongodb/layouts/partials/header/metaRedirect.html
@@ -50,3 +50,8 @@
   <meta http-equiv="refresh" content="0;url=https://www.mongodb.com/docs/drivers/java/sync/v4.3/" />
 {{ end }}
 
+{{ if ( and ( findRE ".*mongo-java-driver/5.0/driver-reactive/.+" .URL ) ( not ( findRE ".*/apidocs/.*" .URL )) ( not ( findRE ".*/driver-scala/.*" .URL )) ( not ( findRE ".*/whats-new/.*" .URL ))) }}
+  <link rel="canonical" href="https://www.mongodb.com/docs/languages/java/drivers/java-rs/v5.0/"/>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+  <meta http-equiv="refresh" content="0;url=https://www.mongodb.com/docs/languages/java/drivers/java-rs/v5.0/" />
+{{ end }}


### PR DESCRIPTION
This PR adds a redirect for all reactive streams URLs at the legacy GitHub documentation to the new site for the overlapping version v5